### PR TITLE
Add option to specify an extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,13 @@ module.exports = {
       // if not present, the basename of the path
       filename: 'my_app.zip',
 
-      // OPTIONAL: defaults an empty string 
+      // OPTIONAL: defaults to 'zip'
+      // the file extension to use instead of 'zip'
+      extension: 'ext'
+
+      // OPTIONAL: defaults an empty string
       // the prefix for the files included in the zip file
-      pathPrefix: 'relative/path',  
+      pathPrefix: 'relative/path',
 
       // OPTIONAL: defaults to including everything
       // can be a string, a RegExp, or an array of strings and RegExps

--- a/index.js
+++ b/index.js
@@ -64,11 +64,13 @@ ZipPlugin.prototype.apply = function(compiler) {
 			// default to webpack root filename if no filename provided, else the basename of the output path
 			var outputFilename = options.filename || compilation.options.output.filename || path.basename(outputPath);
 
+			var extension = '.' + (options.extension || 'zip');
+
 			// combine the output path and filename
 			var outputPathAndFilename = path.resolve(
 				compilation.options.output.path, // ...supporting both absolute and relative paths
 				outputPath,
-				path.basename(outputFilename, '.zip') + '.zip' // ...and filenames with and without a .zip extension
+				path.basename(outputFilename, '.zip') + extension // ...and filenames with and without a .zip extension
 			);
 
 			// resolve a relative output path with respect to webpack's root output path

--- a/test/test.js
+++ b/test/test.js
@@ -271,6 +271,12 @@ test('naming - specified filename with .zip, with webpack filename', async t => 
 	t.ok(readFileSync(join(out, 'my_app.zip')), '.zip exists');
 });
 
+test('naming - specified filename and extension, no webpack filename', async t => {
+	const out = randomPath();
+	await runWithOptions({ path: out }, { filename:'file', ext: 'ext'})
+	t.ok(readFileSync(join(out, 'file.ext')));
+});
+
 test('naming - specified relative path, no webpack filename', async t => {
 	const out = randomPath();
 	await runWithOptions({ path: out }, { path: 'zip' });

--- a/test/test.js
+++ b/test/test.js
@@ -273,8 +273,26 @@ test('naming - specified filename with .zip, with webpack filename', async t => 
 
 test('naming - specified filename and extension, no webpack filename', async t => {
 	const out = randomPath();
-	await runWithOptions({ path: out }, { filename:'file', ext: 'ext'})
+	await runWithOptions({ path: out }, { filename:'file', extension: 'ext'})
 	t.ok(readFileSync(join(out, 'file.ext')));
+});
+
+test('naming - specified extension, webpack filename', async t => {
+	const out = randomPath();
+	await runWithOptions({ path: out, filename: 'bundle.js' }, { extension: 'ext'})
+	t.ok(readFileSync(join(out, 'bundle.js.ext')));
+});
+
+test('naming - specified extension, no webpack filename', async t => {
+	const out = randomPath();
+	await runWithOptions({ path: out }, { extension: 'ext'})
+	t.ok(readFileSync(join(out, basename(out) + '.ext')));
+});
+
+test('naming - specified relative path and extension, no webpack filename', async t => {
+	const out = randomPath();
+	await runWithOptions({ path: out }, { path: 'zip', extension: 'ext'})
+	t.ok(readFileSync(join(out, 'zip', 'zip.ext')));
 });
 
 test('naming - specified relative path, no webpack filename', async t => {

--- a/test/test.js
+++ b/test/test.js
@@ -274,25 +274,31 @@ test('naming - specified filename with .zip, with webpack filename', async t => 
 test('naming - specified filename and extension, no webpack filename', async t => {
 	const out = randomPath();
 	await runWithOptions({ path: out }, { filename:'file', extension: 'ext'})
-	t.ok(readFileSync(join(out, 'file.ext')));
+	t.truthy(readFileSync(join(out, 'file.ext')), '.ext exists');
 });
 
 test('naming - specified extension, webpack filename', async t => {
 	const out = randomPath();
 	await runWithOptions({ path: out, filename: 'bundle.js' }, { extension: 'ext'})
-	t.ok(readFileSync(join(out, 'bundle.js.ext')));
+	t.truthy(readFileSync(join(out, 'bundle.js.ext')), '.ext exists');
 });
 
 test('naming - specified extension, no webpack filename', async t => {
 	const out = randomPath();
 	await runWithOptions({ path: out }, { extension: 'ext'})
-	t.ok(readFileSync(join(out, basename(out) + '.ext')));
+	t.truthy(readFileSync(join(out, '[name].js.ext')), '.ext exists');
 });
 
 test('naming - specified relative path and extension, no webpack filename', async t => {
 	const out = randomPath();
 	await runWithOptions({ path: out }, { path: 'zip', extension: 'ext'})
-	t.ok(readFileSync(join(out, 'zip', 'zip.ext')));
+	t.truthy(readFileSync(join(out, 'zip', '[name].js.ext')), '.ext exists');
+});
+
+test('naming - specified relative path with slash and extension, no webpack filename', async t => {
+	const out = randomPath();
+	await runWithOptions({ path: out }, { path: './zip', extension: 'ext'})
+	t.truthy(readFileSync(join(out, 'zip', '[name].js.ext')), '.ext exists');
 });
 
 test('naming - specified relative path, no webpack filename', async t => {


### PR DESCRIPTION
Allows the plugin to create .zip files that end with an extension that is not '.zip.'

If no extension is supplied, '.zip' will be used by default.

i.e.:
```new ZipPlugin(); // bundle.js.zip```
```new ZipPlugin({extension: 'ext'}); // bundle.js.ext```