### PR TITLE
Change hook from emit to done

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ ZipPlugin.prototype.apply = function(compiler) {
         throw new Error('"pathPrefix" must be a relative path');
     }
 
-	compiler.plugin('emit', function(compilation, callback) {
+	compiler.plugin('done', function(compilation, callback) {
 		// assets from child compilers will be included in the parent
 		// so we should not run in child compilers
 		if (this.isChild()) {


### PR DESCRIPTION
I cant see any reason why this cant be at the 'done' hook.

'emit' is bad, because other plugins use this and 'after-emit' to do other stuff. zip should be the last step as a zipped file does not usually need any modification by other webpack plugins.

https://webpack.js.org/api/compiler/#event-hooks

Ex. I got trouble using replace-in-file-webpack-plugin because of this, even after I changed replace plugin to 'emit' hook