### PR TITLE
use for..of with Object.keys (compatibility rspack)

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,7 @@ ZipPlugin.prototype.apply = function(compiler) {
 		const pathMapper = options.pathMapper || function(x) { return x; };
 
 		// populate the zip file with each asset
-		for (const nameAndPath in compilation.assets) {
-			if (!compilation.assets.hasOwnProperty(nameAndPath)) continue;
+		for (const nameAndPath of Object.keys(compilation.assets)) {
 
 			// match against include and exclude, which may be strings, regexes, arrays of the previous or omitted
 			if (!ModuleFilenameHelpers.matchObject({ include: options.include, exclude: options.exclude }, nameAndPath)) continue;


### PR DESCRIPTION
## What and why

We replace the for loop with `for..of` and `Object.keys`.

When migrating to [rspack](https://rspack.dev/), I got the error the method `hasOwnProperty` was not found. This PR will make sure that `zip-webpack-plugin` is compatible with rspack.

## Node Compatibility
[`for..of`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of#browser_compatibility) is supported from Node 0.12.
[`Object.keys`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#browser_compatibility) is supported from Node 0.10.

The oldest Node version currently supported is Node.js 16, so this is a safe change.

## Testing
I have run `npm install` and `npm test` on the project.

In order to make the tests pass, I had to run `export NODE_OPTIONS=--openssl-legacy-provider` and I had to apply the following changes to make the tests pass:
```diff
diff --git a/test/test.js b/test/test.js
@@ -210,7 +210,7 @@ test('zipOptions', async t => {
 		},
 	});
 
-	t.is(readFileSync(join(out, 'bundle.js.zip')).length, process.platform === 'win32' ? 57642 : 57637);
+	t.is(readFileSync(join(out, 'bundle.js.zip')).length, process.platform === 'win32' ? 57642 : 57636);
 });
 
 test('fileOptions and zipOptions', async t => {
@@ -226,7 +226,7 @@ test('fileOptions and zipOptions', async t => {
 		},
 	});
 
-	t.is(readFileSync(join(out, 'bundle.js.zip')).length, process.platform === 'win32' ? 57726 : 57721);
+	t.is(readFileSync(join(out, 'bundle.js.zip')).length, process.platform === 'win32' ? 57726 : 57720);
 });
 
 test('pathPrefix', async t => {
```

I think the difference in size is because of updates to zip over the years. Let me know if you want me to add this change. Also the package lock is different now.