### PR TITLE
use compiler.webpack.sources.RawSource for rspack compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ function ZipPlugin(options) {
 
 ZipPlugin.prototype.apply = function(compiler) {
 	const options = this.options;
-	const isWebpack4 = compiler.webpack === undefined || webpack.version.startsWith('4.');
+	const isWebpack4 = webpack.version.startsWith('4.');
+	// Prefer `compiler.webpack` instead of webpack or webpack-sources import (rspack compatibility hack)
+	const { RawSource } = compiler.webpack && compiler.webpack.sources || webpackSources;
 
     if (options.pathPrefix && path.isAbsolute(options.pathPrefix)) {
         throw new Error('"pathPrefix" must be a relative path');
@@ -84,7 +86,6 @@ ZipPlugin.prototype.apply = function(compiler) {
 				outputPathAndFilename
 			);
 
-			const RawSource = isWebpack4 ? webpackSources.RawSource : compiler.webpack.sources.RawSource;
 			// add our zip file to the assets
 			const zipFileSource = new RawSource(Buffer.concat(bufs));
 			if (isWebpack4) {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const ModuleFilenameHelpers = require('webpack/lib/ModuleFilenameHelpers');
 const webpack = require('webpack');
 // Webpack 5 exposes the sources property to ensure the right version of webpack-sources is used.
 // require('webpack-sources') approach may result in the "Cannot find module 'webpack-sources'" error.
-const { RawSource } = webpack.sources || require('webpack-sources');
+const webpackSources = webpack.sources || require('webpack-sources');
 const yazl = require('yazl');
 
 function ZipPlugin(options) {
@@ -19,7 +19,7 @@ function ZipPlugin(options) {
 
 ZipPlugin.prototype.apply = function(compiler) {
 	const options = this.options;
-	const isWebpack4 = webpack.version.startsWith('4.');
+	const isWebpack4 = compiler.webpack === undefined || webpack.version.startsWith('4.');
 
     if (options.pathPrefix && path.isAbsolute(options.pathPrefix)) {
         throw new Error('"pathPrefix" must be a relative path');
@@ -84,6 +84,7 @@ ZipPlugin.prototype.apply = function(compiler) {
 				outputPathAndFilename
 			);
 
+			const RawSource = isWebpack4 ? webpackSources.RawSource : compiler.webpack.sources.RawSource;
 			// add our zip file to the assets
 			const zipFileSource = new RawSource(Buffer.concat(bufs));
 			if (isWebpack4) {


### PR DESCRIPTION
### Context

Though `compiler.webpack.sources` isn't documented in webpack, it's widely used in popular plugins like [copy-webpack-plugin](https://github.com/webpack-contrib/copy-webpack-plugin/blob/master/src/index.js#L288), [css-minimizer-webpack-plugin](https://github.com/webpack-contrib/css-minimizer-webpack-plugin/blob/master/src/index.js#L501), [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin/blob/main/index.js#L1025).  And it's mentioned in [rspack doc](https://rspack.dev/api/plugin-api/compilation-hooks#process-assets-examples). The benefit is to make sure it's referencing the same webpack instance and same sources.RawSource.  

It wouldn't be a problem until rspack broke its [JsSource.__to_binding](https://github.com/web-infra-dev/rspack/pull/7828/files#diff-68f9eb14e3c80f79200ee1908d7d37e466bb3f4b353a07116b535eadf5b8811bR23) for zip-webpack-plugin by converting our Buffer type RawSource to utf8 string  `Buffer.from(source.source()).toString("utf-8")`.   More background on rspack, based on my test, it uses the RawSource in its compiled javascript rather than always require "webpack-sources",  which makes the check `source instanceof RawSource` always return false with current zip-webpack-plugin code.

For sure, it should be something they fix on their side. But just that I found this quick fix that doesn't hurt zip-webpack-plugin but could easily bypass that rspack bug for now. 

### Test

I have run `npm test`, the only difference is the file size

```
  test/test.js:229

   228:                                                                                                       
   229:   t.is(readFileSync(join(out, 'bundle.js.zip')).length, process.platform === 'win32' ? 57726 : 57721);
   230: });                                                                                                   

  Difference:

  - 57713
  + 57721

  › test/test.js:229:4



  zipOptions

  test/test.js:213

   212:                                                                                                       
   213:   t.is(readFileSync(join(out, 'bundle.js.zip')).length, process.platform === 'win32' ? 57642 : 57637);
   214: });                                                                                                   

  Difference:

  - 57629
  + 57637
```